### PR TITLE
Patch for issue #1 - DM errors publish help to calling channel.

### DIFF
--- a/movienightbot/actions/help.py
+++ b/movienightbot/actions/help.py
@@ -31,7 +31,14 @@ class HelpAction(BaseAction):
         return embed
 
     async def action(self, msg):
-        await msg.author.send(content=None, embed=self._build_help_embed(msg.guild.id))
+        embed_data = self._build_help_embed(msg.guild.id)
+        try:
+            await msg.author.send(content=None, embed=embed_data)
+        except discord.Forbidden as ex:
+            if ex.code == 50007:
+                await msg.channel.send(content=None, embed=embed_data)
+            else:
+                raise
 
     @property
     def help_text(self):


### PR DESCRIPTION
Unless a user relaxes their permissions or adds the bot as a friend on Discord, DMs will likely fail for anyone with stricter DM/Privacy settings.   

This patch catches ther `discord.Forbidden` error and checks for the correct status code `50007` before attempting to send the help text to the calling channel. 

A full list of status/op-codes can be found here:  https://discordapp.com/developers/docs/topics/opcodes-and-status-codes