### PR TITLE
Tidy up regex for IMDB URL

### DIFF
--- a/movienightbot/util.py
+++ b/movienightbot/util.py
@@ -106,7 +106,7 @@ emojis_text = {
 emojis_unicode = {v: k for k, v in emojis_text.items()}
 
 
-imdb_url_regex = re.compile("title\/tt([0-9]*)\/")  # noqa
+imdb_url_regex = re.compile(r"title/tt([0-9]+)/?")  # noqa
 
 
 async def add_vote_emojis(vote_msg: discord.Message, movie_votes: MovieVote):


### PR DESCRIPTION
This changes the IMDB URL regular expression to make the trailing slash optional.  
It also makes the ID number required and converts the definition to a raw string to avoid escape sequence shenanigans. 