### PR TITLE
Print an OAuth link to the log when starting up.

### DIFF
--- a/movienightbot/application.py
+++ b/movienightbot/application.py
@@ -21,20 +21,23 @@ _user_vote_controller = UserVoteController()
 logger = logging.getLogger("movienightbot")
 
 client._cached_app_info = None
+
+
 async def generate_invite_link(permissions=discord.Permissions(388160), guild=None):
-    if client._cached_app_info == None:
-        logger.info("Caching App Info...");
+    if client._cached_app_info is None:
+        logger.info("Caching App Info...")
         client._cached_app_info = await client.application_info()
     return discord.utils.oauth_url(client._cached_app_info.id, permissions=permissions, guild=guild)
+
 
 @client.event
 async def on_ready():
     print(f"Logged in as user {client.user}")
     logger.info(f"Logged in as user {client.user}")
-    
+
     auth_url = await generate_invite_link()
-    logger.info(f"Bot Invite URL:  {auth_url}")    
-    
+    logger.info(f"Bot Invite URL:  {auth_url}")
+
     await client.change_presence(
         status=discord.Status.idle,
         activity=discord.Game(name="Tracking your shitty movie taste"),

--- a/movienightbot/application.py
+++ b/movienightbot/application.py
@@ -20,11 +20,21 @@ _user_vote_controller = UserVoteController()
 
 logger = logging.getLogger("movienightbot")
 
+client._cached_app_info = None
+async def generate_invite_link(permissions=discord.Permissions(388160), guild=None):
+    if client._cached_app_info == None:
+        logger.info("Caching App Info...");
+        client._cached_app_info = await client.application_info()
+    return discord.utils.oauth_url(client._cached_app_info.id, permissions=permissions, guild=guild)
 
 @client.event
 async def on_ready():
     print(f"Logged in as user {client.user}")
     logger.info(f"Logged in as user {client.user}")
+    
+    auth_url = await generate_invite_link()
+    logger.info(f"Bot Invite URL:  {auth_url}")    
+    
     await client.change_presence(
         status=discord.Status.idle,
         activity=discord.Game(name="Tracking your shitty movie taste"),

--- a/movienightbot/application.py
+++ b/movienightbot/application.py
@@ -27,7 +27,9 @@ async def generate_invite_link(permissions=discord.Permissions(388160), guild=No
     if client._cached_app_info is None:
         logger.info("Caching App Info...")
         client._cached_app_info = await client.application_info()
-    return discord.utils.oauth_url(client._cached_app_info.id, permissions=permissions, guild=guild)
+    return discord.utils.oauth_url(
+        client._cached_app_info.id, permissions=permissions, guild=guild
+    )
 
 
 @client.event

--- a/movienightbot/util.py
+++ b/movienightbot/util.py
@@ -54,8 +54,8 @@ End the vote with the :octagonal_sign: emoji.""",
             )
 
         embed.add_field(
-            name=movie_info, 
-            value=score, 
+            name=movie_info,
+            value=score,
             inline=False,
         )
     embed.set_footer(text="Movie time is")

--- a/movienightbot/util.py
+++ b/movienightbot/util.py
@@ -54,7 +54,9 @@ End the vote with the :octagonal_sign: emoji.""",
             )
 
         embed.add_field(
-            name=movie_info, value=score, inline=False,
+            name=movie_info, 
+            value=score, 
+            inline=False,
         )
     embed.set_footer(text="Movie time is")
     today = datetime.datetime.utcnow().date()


### PR DESCRIPTION
Like it says on the tin, prints the OAuth server join URL to the console/logs when the bot starts.  
This just makes it easier to add the bot to a server.  

Other bots may only print this if the bot has no servers in its database/registry - I was too lazy to bother with that checking.  This could be improved but for now does all that may be needed of it.  
Permissions required by the bot are hard-coded into the auth link.  The permissions may need to be revised or a config-file option added in order to allow customizing the permissions bitmask.  