### PR TITLE
Fix dpytest tests

### DIFF
--- a/movienightbot/application.py
+++ b/movienightbot/application.py
@@ -163,7 +163,7 @@ async def on_raw_reaction_add(payload):
 
     # Update the vote message
     embed = build_vote_embed(server_id)
-    await message.edit(content=None, embed=embed, supress=False)
+    await message.edit(content=None, embed=embed, suppress=False)
 
 
 @client.event

--- a/movienightbot/httpserver.py
+++ b/movienightbot/httpserver.py
@@ -9,12 +9,12 @@ import re
 
 from movienightbot.db.controllers import (
     MoviesController,
-	GenreController,
-	VoteController,
-	MovieVoteController,
-	UserVoteController,
-	Movie,
-	Vote,
+    GenreController,
+    VoteController,
+    MovieVoteController,
+    UserVoteController,
+    Movie,
+    Vote,
 )
 
 logger = logging.getLogger("movienightbot")

--- a/movienightbot/httpserver.py
+++ b/movienightbot/httpserver.py
@@ -7,7 +7,15 @@ import logging
 import json
 import re
 
-from movienightbot.db.controllers import *
+from movienightbot.db.controllers import (
+    MoviesController,
+	GenreController,
+	VoteController,
+	MovieVoteController,
+	UserVoteController,
+	Movie,
+	Vote,
+)
 
 logger = logging.getLogger("movienightbot")
 

--- a/movienightbot/util.py
+++ b/movienightbot/util.py
@@ -27,11 +27,14 @@ async def cleanup_messages(
     sec_delay : int
         The number of seconds to wait before deleting the message. Default 10
     """
-    loop = asyncio.get_event_loop()
     for message in messages:
-        loop.create_task(message.delete(delay=sec_delay))
-        # Need sleep here so don't overwhelm API
-        await asyncio.sleep(0.2)
+        # Adding `delay` kwarg spawns a task, so wrapping that task in a task is redundant...
+        # These tasks cause dpytest to break, and py-cord supposedly has "sane rate-limiting"
+        # So tasks here are being removed all together.
+        # Another mention, we could/should leverage channel.delete_messages() for bulk cleanup, however
+        #  dpytest doesn't support it yet either lol.
+        await asyncio.sleep(sec_delay)
+        await message.delete()
 
 
 async def delete_thread(thread: discord.Thread, sec_delay: int = 10) -> None:

--- a/tests/actions/test_suggested.py
+++ b/tests/actions/test_suggested.py
@@ -12,5 +12,7 @@ async def test_suggested(client):
     assert (
         test.verify()
         .message()
-        .content(f"Suggestions can be found at {base_url}/suggested/{guild_id}")
+        .content(
+            f"Suggestions can be found at {base_url}/movies.html?server={guild_id}&view=suggested"
+        )
     )

--- a/tests/actions/test_watched.py
+++ b/tests/actions/test_watched.py
@@ -12,5 +12,7 @@ async def test_watched(client):
     assert (
         test.verify()
         .message()
-        .content(f"Watched movies can be found at {base_url}/watched/{guild_id}")
+        .content(
+            f"Watched movies can be found at {base_url}/movies.html?server={guild_id}&view=watched"
+        )
     )


### PR DESCRIPTION
This PR contains the bot changes required to make dpytest work with py-cord and the current develop branch.  

Currently, dpytest is not working well with py-cord 2.x.  As a result of dpytest not being updated, these changes require a custom version of dpytest which I have modified to work with py-cord 2.x.  The modified dpytest can be found here:  https://github.com/itsTheFae/dpytest/tree/py-cord-v2

Perhaps later I'll make a commit which pulls this modified version in the setup.  Depends entirely on if I get feedback from dpytest devs and the level of fucks I care to give in the first place.  